### PR TITLE
Remove show option in dropdown

### DIFF
--- a/client/src/components/lifelines/Dropdown.tsx
+++ b/client/src/components/lifelines/Dropdown.tsx
@@ -120,10 +120,10 @@ export const LifelineDropdown = ({
           <StyledChevronDown />
         </StyledMenuButton>
         <StyledMenuList>
-          <StyledMenuItem disabled={!isDisplayed}>
+          {/* <StyledMenuItem disabled={!isDisplayed}>
             <StyledShow isEnabled={isDisplayed} />
             <MenuText isEnabled={isDisplayed}>Show</MenuText>
-          </StyledMenuItem>
+          </StyledMenuItem> */}
           <StyledMenuItem
             disabled={!isCustomizable}
             onSelect={() => setShowEditDialog(true)}


### PR DESCRIPTION
<!--
Template sourced from https://github.com/hack4impact-uiuc/life-after-hate
Shoutout to the wonderful LAH team!
-->

## Status:

<!--
:rocket: Ready
:construction: In development
:no_entry_sign: Do not merge
-->

## Description
Comments out option to show / hide lifeline. Temporary until able to fix functionality. Will show 1 or 3 lifelines (or less if fewer lifelines are in the entire lifelines array).
<!--
A few sentences describing the overall goals of the pull request's commits.
-->

Fixes #<number>

## Todos

<!--
- [ ] Tests
- [ ] Documentation
-->

## Deadline (from the issue)

## Screenshots

<!--
Mac OS Screenshots: ctrl + shift + cmd + 3 (entire screen) or 4 (selection of screen), then paste in editor
Mac OS GIFs: Try using Kap
Linux/Windows: Ctrl + Alt + PrintScreen (of a window) or Ctrl + Shift + PrintScreen (selection of screen), then paste in editor
-->
